### PR TITLE
feat: Add subcommand to dump default dynamic config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -273,6 +279,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -287,6 +299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -384,6 +406,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -505,6 +539,12 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "equivalent"
@@ -666,7 +706,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-events-runner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -675,6 +715,7 @@ dependencies = [
  "futures",
  "git2",
  "humantime",
+ "insta",
  "k8s-openapi 0.20.0",
  "k8s-openapi 0.22.0",
  "kube 0.87.2",
@@ -705,13 +746,26 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "libc",
  "libgit2-sys",
  "log",
  "openssl-probe",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1001,6 +1055,25 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "globset",
+ "lazy_static",
+ "linked-hash-map",
+ "pest",
+ "pest_derive",
+ "regex",
+ "ron",
+ "serde",
+ "similar",
+ "walkdir",
 ]
 
 [[package]]
@@ -1352,6 +1425,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,7 +1774,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -1755,6 +1834,17 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -1889,6 +1979,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,7 +2052,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2073,6 +2172,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "slab"
@@ -2316,7 +2421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.5.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2337,7 +2442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.5.0",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
@@ -2533,6 +2638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2731,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["kubernetes", "operator", "git", "events", "runner"]
 license = "MIT"
 name = "git-events-runner"
 repository = "https://github.com/alex-karpenko/git-events-runner"
-version = "0.1.0"
+version = "0.1.1"
 
 [[bin]]
 doc = false
@@ -74,3 +74,6 @@ tokio = { version = "1", features = [
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 uuid = { version = "1.8.0", features = ["v4"] }
+
+[dev-dependencies]
+insta = { version = "1", features = ["glob", "ron", "redactions", "filters"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,11 @@
 
 ## In work
 
+- chart: update to specify container registry and use docker.io by default
 - action:
     - config to restrict the maximum number of running acton jobs;
     - config to restrict jobs' duration;
     - config parameters to specify node affinity, toleration, annotations and additional labels for action job.
-- chart: update to specify container registry and use docker.io by default
 
 ## Next release
 
@@ -18,7 +18,6 @@
 ## Wishes
 
 - tests: automate everything possible
-- chart/cli: Make new subcommand to dump out default config and update it in the chart as part of CD
 - refactor: looks like scheduler shouldn't be under RwLock because it's `add` method uses internal mutability
 - gitrepo: update to use `gix` instead of `git2`, if possible
 - hooks: implement hook requests rate control/throttling
@@ -34,3 +33,4 @@
 
 - images: publish images to docker hub
 - images: update default action-worker image to use the latest Ubuntu LTS version
+- chart/cli: Make new subcommand to dump out default config and verify it in the chart as part of CI

--- a/src/bin/git-events-runner.rs
+++ b/src/bin/git-events-runner.rs
@@ -1,7 +1,6 @@
 use git_events_runner::{
-    cache::ApiCacheStore,
-    cache::SecretsCache,
-    cli::{Cli, CliConfig},
+    cache::{ApiCacheStore, SecretsCache},
+    cli::{Cli, CliConfig, CliConfigDumpOptions},
     config::RuntimeConfig,
     controller::{run_leader_controllers, State},
     jobs, leader,
@@ -26,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli {
         Cli::Crds => generate_crds(),
+        Cli::Config(options) => generate_config_yaml(options),
         Cli::Run(cli_config) => run(cli_config).await,
     }
 }
@@ -162,6 +162,20 @@ fn generate_crds() -> anyhow::Result<()> {
     for crd in crds {
         print!("---\n{crd}");
     }
+
+    Ok(())
+}
+
+/// Print default dynamic config to stdout as YAML
+fn generate_config_yaml(options: CliConfigDumpOptions) -> anyhow::Result<()> {
+    let opts = if options.helm_template {
+        git_events_runner::config::YamlConfigOpts::HelmTemplate
+    } else {
+        git_events_runner::config::YamlConfigOpts::Raw
+    };
+
+    let yaml_str = RuntimeConfig::to_yaml_string(opts)?;
+    print!("{yaml_str}");
 
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,8 @@ const DEFAULT_LEADER_LOCK_LEASE_NAME: &str = "git-events-runner-leader-lock";
 pub enum Cli {
     /// Print CRD definitions to stdout
     Crds,
+    /// Print default dynamic config YAML to stdout
+    Config(CliConfigDumpOptions),
     /// Run K8s controller
     Run(CliConfig),
 }
@@ -67,6 +69,13 @@ pub struct CliConfig {
     // /// Write logs in JSON format
     // #[arg(short, long)]
     // json_log: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct CliConfigDumpOptions {
+    /// Include some templates for Helm chart
+    #[arg(short = 't', long)]
+    pub helm_template: bool,
 }
 
 impl Cli {

--- a/src/snapshots/git_events_runner__config__tests__yaml_config_consistency.snap
+++ b/src/snapshots/git_events_runner__config__tests__yaml_config_consistency.snap
@@ -1,0 +1,5 @@
+---
+source: src/config.rs
+expression: config_yaml_string
+---
+"action:\n  workdir:\n    mountPath: /action_workdir\n    volumeName: action-workdir\n  defaultServiceAccount: \'{{ include \"git-events-runner.actionJobServiceAccountName\" . }}\'\n  ttlSecondsAfterFinished: 7200\n  containers:\n    cloner:\n      name: action-cloner\n      image: ghcr.io/alex-karpenko/git-events-runner/gitrepo-cloner:{{ .Chart.AppVersion }}\n    worker:\n      name: action-worker\n      image: ghcr.io/alex-karpenko/git-events-runner/action-worker:{{ .Chart.AppVersion }}\n      variablesPrefix: ACTION_JOB_\ntrigger:\n  webhook:\n    defaultAuthHeader: x-trigger-auth\n"


### PR DESCRIPTION
1. Introduce `config` subcommand to dump default dynamic config.
2. Update Helm chart to use config value in CI (https://github.com/alex-karpenko/helm-charts/pull/19)
3. Add test to ensure non-drifting value of the config string