### PR TITLE
fix: updates unit tests to use Kubernetes 1.36 (latest k3s version)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2137ce22f50d4c43ce098daf41c904cc700de1ce8bc2daf53ed4e702180a464"
+checksum = "e84c00697eca0d99ddc657698f9238f7426bac392c5ea859f5efdfdd2b719dd7"
 dependencies = [
  "linktime-proc-macro",
 ]
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ tower_governor = { version = "0.8.0", features = ["tracing"] }
 
 [dev-dependencies]
 base64 = "0.22.1"
-dtor = "1.0.3"
+dtor = "1.0.4"
 insta = { version = "1.47.2", features = [
     "glob",
     "ron",

--- a/src/tests/containers/k3s.rs
+++ b/src/tests/containers/k3s.rs
@@ -14,12 +14,15 @@ pub const K3S_API_PORT: ContainerPort = ContainerPort::Tcp(6443);
 
 pub const K3S_IMAGE_TAG_ENV_VAR: &str = "CARGO_TEST_K3S_IMAGE_TAG";
 pub const KUBE_VERSION_ENV_VAR: &str = "CARGO_TEST_KUBE_VERSION";
-pub const KUBE_VERSION_DEFAULT: &str = "1.33";
+pub const KUBE_VERSION_DEFAULT: &str = "1.36";
 
-const AVAILABLE_K3S_IMAGE_TAGS: [(&str, &str); 8] = [
-    ("1.33", "v1.33.1-k3s1"),
-    ("1.32", "v1.32.5-k3s1"),
-    ("1.31", "v1.31.9-k3s1"),
+const AVAILABLE_K3S_IMAGE_TAGS: [(&str, &str); 11] = [
+    ("1.36", "v1.36.1-k3s1"),
+    ("1.35", "v1.35.5-k3s1"),
+    ("1.34", "v1.34.8-k3s1"),
+    ("1.33", "v1.33.12-k3s1"),
+    ("1.32", "v1.32.13-k3s1"),
+    ("1.31", "v1.31.14-k3s1"),
     ("1.30", "v1.30.13-k3s1"),
     ("1.29", "v1.29.15-k3s1"),
     ("1.28", "v1.28.15-k3s1"),


### PR DESCRIPTION
## Summary

  Updates unit tests to use Kubernetes 1.36 (latest k3s version) and bumps related dependencies to their latest versions.

  ## Changes

  - **Default Kubernetes Version**: Updated from 1.33 to 1.36
  - **Supported K3s Versions**: Expanded test coverage to include Kubernetes 1.36, 1.35, and 1.34 with their latest k3s releases
  - **Dependencies**: Updated `dtor` dev-dependency from 1.0.3 to 1.0.4 in Cargo.toml

  ## Files Changed

  - `Cargo.toml` - Updated dtor dependency version (1.0.3 → 1.0.4)
  - `Cargo.lock` - Lockfile updates reflecting dependency changes
  - `src/tests/containers/k3s.rs` - Updated default KUBE_VERSION and AVAILABLE_K3S_IMAGE_TAGS array

  ## Testing

  Unit tests now run against Kubernetes 1.36 (latest k3s) by default, ensuring compatibility with the most recent stable releases.

  This PR updates the test infrastructure to use the latest Kubernetes version and ensures the test environment stays current.